### PR TITLE
Make proper use of SciJava parameters

### DIFF
--- a/scripts/jython_Ops.py
+++ b/scripts/jython_Ops.py
@@ -1,10 +1,8 @@
-#@ImageJ ij
+# @ImagePlus imp
+# @OpService ops
+# @OUTPUT ImagePlus result
 
-from ij import IJ
-
-imp =IJ.getImage();
 hMin = 500
 thresh = 500
 peakFlooding = 80
-result = ij.op().run("HWatershed", imp, hMin, thresh, peakFlooding );
-result.show()
+result = ops.run("HWatershed", imp, hMin, thresh, peakFlooding );


### PR DESCRIPTION
* Require just the `OpService`, not the full `ImageJ` context, as a parameter
* Avoid calling `ij.IJ` to get current image
* Avoid directly showing the result; declared `@OUTPUT` will be shown automatically
